### PR TITLE
Adds list_templates management command and uses the results for tailwind content config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,6 @@ ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
-"src/django_tailwind_cli/management/commands/list_templates.py" = ["ARG002"]
 
 # Coverage
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ ban-relative-imports = "all"
 
 [tool.ruff.per-file-ignores]
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
+"src/django_tailwind_cli/management/commands/list_templates.py" = ["ARG002"]
 
 # Coverage
 [tool.coverage.run]

--- a/src/django_tailwind_cli/management/commands/list_templates.py
+++ b/src/django_tailwind_cli/management/commands/list_templates.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 
 class Command(BaseCommand):
-    def handle(self, *args: Any, **options: Any) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:  # noqa: ARG002
         template_files: List[str] = []
         app_template_dirs = get_app_template_dirs("templates")
         for app_template_dir in app_template_dirs:

--- a/src/django_tailwind_cli/management/commands/list_templates.py
+++ b/src/django_tailwind_cli/management/commands/list_templates.py
@@ -1,12 +1,11 @@
 # Based on https://noumenal.es/notes/tailwind/django-integration/
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Union
+from typing import Any, List, Union
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.template.utils import get_app_template_dirs
-
 
 
 class Command(BaseCommand):

--- a/src/django_tailwind_cli/management/commands/list_templates.py
+++ b/src/django_tailwind_cli/management/commands/list_templates.py
@@ -1,13 +1,12 @@
 # Based on https://noumenal.es/notes/tailwind/django-integration/
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Union
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.template.utils import get_app_template_dirs
 
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 class Command(BaseCommand):

--- a/src/django_tailwind_cli/management/commands/list_templates.py
+++ b/src/django_tailwind_cli/management/commands/list_templates.py
@@ -1,16 +1,18 @@
 # Based on https://noumenal.es/notes/tailwind/django-integration/
 import os
+from typing import TYPE_CHECKING, Any, List, Union
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.template.utils import get_app_template_dirs
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
 
 class Command(BaseCommand):
-    help = "List all template files"
-
-    def handle(self, *args, **options):
-        template_files = []
+    def handle(self, *args: Any, **options: Any) -> None:
+        template_files: List[str] = []
         app_template_dirs = get_app_template_dirs("templates")
         for app_template_dir in app_template_dirs:
             template_files += self.list_template_files(app_template_dir)
@@ -18,8 +20,8 @@ class Command(BaseCommand):
 
         self.stdout.write("\n".join(template_files))
 
-    def list_template_files(self, template_dir):
-        template_files = []
+    def list_template_files(self, template_dir: Union[str, Path]) -> List[str]:
+        template_files: List[str] = []
         for dirpath, _, filenames in os.walk(str(template_dir)):
             for filename in filenames:
                 if filename.endswith(".html") or filename.endswith(".txt"):

--- a/src/django_tailwind_cli/management/commands/list_templates.py
+++ b/src/django_tailwind_cli/management/commands/list_templates.py
@@ -1,0 +1,27 @@
+# Based on https://noumenal.es/notes/tailwind/django-integration/
+import os
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from django.template.utils import get_app_template_dirs
+
+
+class Command(BaseCommand):
+    help = "List all template files"
+
+    def handle(self, *args, **options):
+        template_files = []
+        app_template_dirs = get_app_template_dirs("templates")
+        for app_template_dir in app_template_dirs:
+            template_files += self.list_template_files(app_template_dir)
+        template_files += self.list_template_files(settings.TEMPLATES[0]["DIRS"])
+
+        self.stdout.write("\n".join(template_files))
+
+    def list_template_files(self, template_dir):
+        template_files = []
+        for dirpath, _, filenames in os.walk(str(template_dir)):
+            for filename in filenames:
+                if filename.endswith(".html") or filename.endswith(".txt"):
+                    template_files.append(os.path.join(dirpath, filename))
+        return template_files

--- a/src/django_tailwind_cli/management/commands/tailwind.py
+++ b/src/django_tailwind_cli/management/commands/tailwind.py
@@ -182,9 +182,12 @@ class Command(BaseCommand):
             self.stdout.write(self.style.SUCCESS(f"Created Tailwind CSS config at '{tailwind_config_file}'"))
 
 
-DEFAULT_TAILWIND_CONFIG = """/** @type {import('tailwindcss').Config} */
-const plugin = require("tailwindcss/plugin");""" + f"""
-const projectRoot = '{settings.BASE_DIR}';""" + """
+DEFAULT_TAILWIND_CONFIG = (
+    """/** @type {import('tailwindcss').Config} */
+const plugin = require("tailwindcss/plugin");"""
+    f"""
+const projectRoot = '{settings.BASE_DIR}';"""
+    """
 const { spawnSync } = require('child_process');
 
 // Calls Django to fetch template files
@@ -229,3 +232,4 @@ module.exports = {
   ],
 }
 """
+)

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -234,6 +234,7 @@ class ListTemplateCommandTestCase(MockedNetworkingProcessesAndShellToolsTestCase
         self.assertIn("templates/tailwind_cli/base.html", out.getvalue().strip())
         self.assertIn("templates/tailwind_cli/tailwind_css.html", out.getvalue().strip())
 
+
 @contextmanager
 def captured_output():
     """Capture the output of a function."""

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -206,6 +206,34 @@ class WatchCommandTestCase(MockedNetworkingProcessesAndShellToolsTestCase):
             self.assertIn("--input", build_cmd)
 
 
+class ListTemplateCommandTestCase(MockedNetworkingProcessesAndShellToolsTestCase):
+    """Test that list_templates command works."""
+
+    def test_list_project_templates(self):
+        """Test that the list_templates command returns our two templates."""
+        with captured_output() as (out, _err):
+            call_command("list_templates")
+        self.assertIn("templates/tailwind_cli/base.html", out.getvalue().strip())
+        self.assertIn("templates/tailwind_cli/tailwind_css.html", out.getvalue().strip())
+        self.assertNotIn("templates/admin", out.getvalue().strip())
+
+    def test_list_all_templates(self):
+        """Test that app templates are also included."""
+        admin_installed_apps = [
+            "django.contrib.contenttypes",
+            "django.contrib.messages",
+            "django.contrib.auth",
+            "django.contrib.admin",
+            "django.contrib.staticfiles",
+            "django_tailwind_cli",
+        ]
+        with self.settings(INSTALLED_APPS=admin_installed_apps):
+            with captured_output() as (out, _err):
+                call_command("list_templates")
+        self.assertIn("templates/admin", out.getvalue().strip())
+        self.assertIn("templates/tailwind_cli/base.html", out.getvalue().strip())
+        self.assertIn("templates/tailwind_cli/tailwind_css.html", out.getvalue().strip())
+
 @contextmanager
 def captured_output():
     """Capture the output of a function."""


### PR DESCRIPTION
This implements [Carlton Gibson's](https://noumenal.es/notes/tailwind/django-integration/) suggestion of using a Django management command to supply the list of templates to tailwind's config file. The advantage being that this should also capture app templates that aren't explicitly overridden in the current project. 

This implements the management command and then also updates the default tailwind config file to use the output.