### PR TITLE
Add support for customized tailwind cli asset name

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -37,11 +37,26 @@ your project.
 `TAILWIND_CLI_SRC_REPO`
 : **Default**: `"tailwindlabs/tailwindcss"`
 
-    Specifies the repository from which the CLI is downloaded. This is useful if you are using a customized version of the CLI, such as [tailwind-cli-extra](https://github.com/dobicinaitis/tailwind-cli-extra/tree/v1.7.12).
+    Specifies the repository from which the CLI is downloaded. This is useful if you are using a customized version of the CLI, such as [tailwind-cli-extra](https://github.com/dobicinaitis/tailwind-cli-extra).
 
     !!! warning
 
-       If you use this option, ensure that you update the `TAILWIND_CLI_VERSION` to match the version of the customized CLI you are using.
+        If you use this option, ensure that you update the `TAILWIND_CLI_VERSION` to match the version of the customized CLI you are using. Additionally, you may need to update the `TAILWIND_CLI_ASSET_NAME` if the asset name is different. See the example below.
+
+`TAILWIND_CLI_ASSET_NAME`:
+: **Default**: `"tailwindcss"`
+
+    Specifies the name of the asset to download from the repository. This option is particularly useful if the customized repository you are using has a different name for the Tailwind CLI asset. For example, the asset name for [tailwind-cli-extra](https://github.com/dobicinaitis/tailwind-cli-extra/releases/latest/) is `tailwindcss-extra`.
+
+    !!! Note
+
+        Here is a full example of using a custom repository and asset name:
+
+        ```python
+        TAILWIND_CLI_SRC_REPO = "dobicinaitis/tailwind-cli-extra"
+        TAILWIND_CLI_ASSET_NAME = "tailwindcss-extra"
+        TAILWIND_CLI_VERSION = "1.7.12"
+        ```
 
 `TAILWIND_CLI_AUTOMATIC_DOWNLOAD`
 : **Default**: `True`

--- a/src/django_tailwind_cli/management/commands/tailwind.py
+++ b/src/django_tailwind_cli/management/commands/tailwind.py
@@ -240,9 +240,10 @@ class Command(TyperCommand):
     @command(name="download_cli", help="Download the Tailwind CSS CLI to .")
     def download_cli(self) -> None:
         dest_file = self.config.get_full_cli_path()
+        extra_msg = "" if self.config.src_repo == self.config.default_src_repo else f" from '{self.config.src_repo}'"
 
         if dest_file.exists():
-            self._write_success(f"Tailwind CSS CLI already exists at '{dest_file}'")
+            self._write_success(f"Tailwind CSS CLI already exists at '{dest_file}'{extra_msg}")
             return
 
         download_url = self.config.get_download_url()
@@ -255,7 +256,7 @@ class Command(TyperCommand):
                 shutil.copyfileobj(source, dest)
         # make cli executable
         dest_file.chmod(0o755)
-        self._write_success(f"Downloaded Tailwind CSS CLI to '{dest_file}'")
+        self._write_success(f"Downloaded Tailwind CSS CLI to '{dest_file}'{extra_msg}")
 
     def _create_tailwind_config_if_not_exists(self) -> None:
         tailwind_config_file = self.config.get_full_config_file_path()

--- a/src/django_tailwind_cli/utils.py
+++ b/src/django_tailwind_cli/utils.py
@@ -16,6 +16,8 @@ from django.conf import settings
 class Config:
     """Configuration for the Tailwind CSS CLI."""
 
+    default_src_repo = "tailwindlabs/tailwindcss"
+
     @property
     def tailwind_version(self) -> str:
         return getattr(settings, "TAILWIND_CLI_VERSION", "3.4.10")
@@ -45,7 +47,11 @@ class Config:
 
     @property
     def src_repo(self) -> str:
-        return getattr(settings, "TAILWIND_CLI_SRC_REPO", "tailwindlabs/tailwindcss")
+        return getattr(settings, "TAILWIND_CLI_SRC_REPO", self.default_src_repo)
+
+    @property
+    def asset_name(self) -> str:
+        return getattr(settings, "TAILWIND_CLI_ASSET_NAME", "tailwindcss")
 
     @staticmethod
     def validate_settings() -> None:
@@ -75,7 +81,7 @@ class Config:
         extension = ".exe" if system == "windows" else ""
         return (
             f"https://github.com/{self.src_repo}/releases/download/"
-            f"v{self.tailwind_version}/tailwindcss-{system}-{machine}{extension}"
+            f"v{self.tailwind_version}/{self.asset_name}-{system}-{machine}{extension}"
         )
 
     def get_full_cli_path(self) -> Path:


### PR DESCRIPTION
The code changes introduce a new setting, `TAILWIND_CLI_ASSET_NAME`. The last release introduced `TAILWIND_CLI_SRC_REPO`, but that alone is not enough to pull from a customized repository. The repository might be using a custom name for the Tailwind CLI file, such as `tailwind-extra`. This case was not taken into account, an oversight on my part.